### PR TITLE
Non-boxed Rc

### DIFF
--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -21,7 +21,7 @@ struct Y {
     x: X,
 }
 impl<C> Resolvable<C> for Y {
-    type Dependency = O<X>;
+    type Dependency = Owned<X>;
 
     fn resolve(x: Self::Dependency) -> Self {
         Y { x: x.value() }
@@ -45,7 +45,7 @@ struct BorrowY {
     y: Rc<Y>,
 }
 impl<C> Resolvable<C> for BorrowY {
-    type Dependency = (O<X>, Rc<Y>);
+    type Dependency = (Owned<X>, Rc<Y>);
 
     fn resolve((x, y): Self::Dependency) -> Self {
         BorrowY {

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -42,10 +42,10 @@ pub fn resolve_owned_y(b: &mut Bencher) {
 #[allow(dead_code)]
 struct BorrowY {
     x: X,
-    y: Rc<Box<Y>>,
+    y: Rc<Y>,
 }
 impl<C> Resolvable<C> for BorrowY {
-    type Dependency = (O<X>, Rc<Box<Y>>);
+    type Dependency = (O<X>, Rc<Y>);
 
     fn resolve((x, y): Self::Dependency) -> Self {
         BorrowY {

--- a/src/container/brw_scope.rs
+++ b/src/container/brw_scope.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use std::mem;
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::HashMap as StdHashMap;

--- a/src/container/brw_scope.rs
+++ b/src/container/brw_scope.rs
@@ -1,10 +1,7 @@
-// NOTE: This depends on a tweaked `TypeId` that doesn't require `T: 'static`
-
 use super::*;
 
 use std::mem;
 use std::any::{Any, TypeId};
-use std::intrinsics;
 use std::cell::RefCell;
 use std::collections::HashMap as StdHashMap;
 use std::hash::BuildHasherDefault;
@@ -12,8 +9,14 @@ use fnv::FnvHasher;
 
 type HashMap<K, V> = StdHashMap<K, V, BuildHasherDefault<FnvHasher>>;
 
+// TODO: This leaks. We need to find a way to drop values
+// efficiently when the scope is dropped.
+// Maybe we could use unboxed closures, so we have:
+// `HashMap<TypeId, (*mut Any, Fn(*mut Any) -> ())>`.
+// Where the `Fn(*mut Any) -> ()` will convert the pointer into a `Rc<T>`
+// and drop it.
 struct TypeMap {
-    refs: HashMap<TypeId, Rc<Box<Any>>>,
+    refs: HashMap<TypeId, *mut Any>,
 }
 
 impl TypeMap {
@@ -33,19 +36,27 @@ impl TypeMap {
         self.refs.get(&Self::key::<T>()).is_some()
     }
 
-    unsafe fn get<T>(&self) -> Rc<Box<T>>
+    unsafe fn get<T>(&self) -> Rc<T>
         where T: 'static
     {
-        let rc = self.refs.get(&Self::key::<T>()).unwrap().clone();
-        
-        mem::transmute(rc)
+        let ptr = self.refs.get(&Self::key::<T>()).unwrap();
+        let rc_ptr = *ptr as *mut T;
+
+        let rc = Rc::from_raw(rc_ptr);
+        let rc_clone = rc.clone();
+
+        Rc::into_raw(rc);
+
+        rc_clone
     }
 
     fn insert<T>(&mut self, t: T)
         where T: 'static
     {
-        let rc: Rc<Box<Any>> = Rc::new(Box::new(t));
-        self.refs.insert(Self::key::<T>(), rc);
+        let rc_ptr = Rc::into_raw(Rc::new(t));
+        let ptr = rc_ptr as *mut Any;
+
+        self.refs.insert(Self::key::<T>(), ptr);
     }
 }
 
@@ -67,7 +78,7 @@ impl Scoped {
     }
 
     #[inline]
-    unsafe fn get<T>(&self) -> Rc<Box<T>>
+    unsafe fn get<T>(&self) -> Rc<T>
         where T: 'static
     {
         self.map.borrow().get::<T>()
@@ -86,7 +97,7 @@ impl Container for Scoped {}
 // NOTE: the 'brw here probably isn't doing much, since the T
 // to resolve needs to live for 'scope anyway
 impl ScopedContainer for Scoped {
-    fn get_or_add<T, D>(&self) -> Rc<Box<T>>
+    fn get_or_add<T, D>(&self) -> Rc<T>
         where T: Resolvable<Self, Dependency = D> + 'static,
               D: ResolvableFromContainer<Self>
     {

--- a/src/container/impls.rs
+++ b/src/container/impls.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use std::rc::Rc;
 use super::*;
 
@@ -84,7 +83,7 @@ impl<C, T, D> ResolvableFromContainer<C> for O<T>
     }
 }
 
-impl<C, T, D> ResolvableFromContainer<C> for Rc<Box<T>>
+impl<C, T, D> ResolvableFromContainer<C> for Rc<T>
     where C: ScopedContainer,
           T: Resolvable<C, Dependency = D> + 'static,
           D: ResolvableFromContainer<C>

--- a/src/container/impls.rs
+++ b/src/container/impls.rs
@@ -1,4 +1,19 @@
+//! Root dependency implementations
+//! 
+//! Root dependencies include:
+//! 
+//! - `()` the only _true_ root dependency that can be used for types
+//! that can be materialised from nothing.
+//! - `Owned<T>` a unique instance of `T`.
+//! - `Rc<T>` a shared instance of `T`.
+//! - `RefCell<T>` a mutable instance of `T`.
+//! 
+//! These can be combined in various ways, like `Rc<RefCell<T>>`.
+//! The trait bounds might be tightened up though, since `Rc<Owned<T>>`,
+//! `Owned<()>` and `RefCell<T>` alone don't make much sense.
+
 use std::rc::Rc;
+use std::cell::RefCell;
 use super::*;
 
 /// `()` is a root dependency that has no dependencies of its own.
@@ -47,20 +62,20 @@ resolve_tuple!((T1, D1, d1)(T2, D2, d2)(T3, D3, d3)(T4, D4, d4)(T5, D5, d5));
 
 /// A root dependency that wraps some other owned dependency type.
 ///
-/// `O` makes it possible to implement `ResolvableFromContainer` for any
+/// `Owned` makes it possible to implement `ResolvableFromContainer` for any
 /// arbitrary `Resolvable` without colliding with other root dependency
 /// implementations.
-pub struct O<T> {
+pub struct Owned<T> {
     t: T,
 }
 
-impl<T> O<T> {
+impl<T> Owned<T> {
     pub fn value(self) -> T {
         self.t
     }
 }
 
-impl<C, T, D> Resolvable<C> for O<T>
+impl<C, T, D> Resolvable<C> for Owned<T>
     where C: Container,
           T: Resolvable<C, Dependency = D>,
           D: ResolvableFromContainer<C>
@@ -68,18 +83,41 @@ impl<C, T, D> Resolvable<C> for O<T>
     type Dependency = D;
 
     fn resolve(dependency: D) -> Self {
-        O { t: T::resolve(dependency) }
+        Owned { t: T::resolve(dependency) }
     }
 }
 
-impl<C, T, D> ResolvableFromContainer<C> for O<T>
+impl<C, T, D> ResolvableFromContainer<C> for Owned<T>
     where C: Container,
           T: Resolvable<C, Dependency = D>,
           D: ResolvableFromContainer<C>
 {
     fn resolve_from_container(container: &C) -> Self {
         let d = D::resolve_from_container(container);
-        O { t: T::resolve(d) }
+        Owned { t: T::resolve(d) }
+    }
+}
+
+impl<C, T, D> Resolvable<C> for RefCell<T>
+    where C: Container,
+          T: Resolvable<C, Dependency = D>,
+          D: ResolvableFromContainer<C>
+{
+    type Dependency = D;
+
+    fn resolve(dependency: D) -> Self {
+        RefCell::new(T::resolve(dependency))
+    }
+}
+
+impl<C, T, D> ResolvableFromContainer<C> for RefCell<T>
+    where C: Container,
+          T: Resolvable<C, Dependency = D>,
+          D: ResolvableFromContainer<C>
+{
+    fn resolve_from_container(container: &C) -> Self {
+        let d = D::resolve_from_container(container);
+        RefCell::new(T::resolve(d))
     }
 }
 

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -31,7 +31,7 @@ pub trait Scope {
 pub trait ScopedContainer
     where Self: Container
 {
-    fn get_or_add<T, D>(&self) -> Rc<Box<T>>
+    fn get_or_add<T, D>(&self) -> Rc<T>
         where T: Resolvable<Self, Dependency = D> + 'static,
               D: ResolvableFromContainer<Self>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics)]
+#![feature(rc_raw)]
 
 extern crate fnv;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,13 +148,6 @@ fn main() {
             println!("y count: {}", Rc::strong_count(&y.y));
         }
 
-        // UNSOUND: borrow with a static dependency
-        //let u: Unsound = scope.resolve();
-
         println!("{:?}", z);
     });
-
-    // UNSOUND: resolve a static dependency
-    //let scope = Scoped::new();
-    //let x: &'static X = scope.brw_or_add();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,7 @@ fn main() {
         {
             let y: BorrowMoreY = scope.resolve();
 
+            println!("{:?}", y);
             println!("y count: {}", Rc::strong_count(&y.y));
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ impl<C, T> Resolvable<C> for XorY<T> {
 struct BorrowY {
     x: X,
     y: Rc<Box<Y>>,
+    k: &'static str
 }
 impl<C> Resolvable<C> for BorrowY {
     type Dependency = (O<X>, Rc<Box<Y>>);
@@ -90,6 +91,7 @@ impl<C> Resolvable<C> for BorrowY {
         BorrowY {
             x: x.value(),
             y: y,
+            k: "some string value"
         }
     }
 }


### PR DESCRIPTION
Playing around with removing the `Box` from the shared `Rc<Box<T>>` dependency type. I feel a bit better about imposing an `Rc<T>` on users rather than an `Rc<Box<T>>`, since `Rc` keeps data on the heap anyways.

> NOTE: This isn't sound yet, it **never** drops dependencies so they're leaked. I'll need to find a solid way to drop values once the scope is dropped.

If I can make this work properly then I'll clean up the design and turn the `main` file into proper tests.